### PR TITLE
Pin pint to version used in development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-- "3.6"
+- "3.7"
 
 branches:
   only:

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,13 @@ try:
 except ModuleNotFoundError:
     system("conda install -c cantera cantera -y")
 
+good_pint_version = "0.11"
 try:
     import pint
+    if pint.__version__ != good_pint_version:
+        raise ModuleNotFoundError
 except ModuleNotFoundError:
-    system("conda install -c conda-forge pint -y")
+    system(f"conda install -c conda-forge pint={good_pint_version} -y")
 
 with open(path.join(here, "pypbomb", "_version.py")) as f:
     __version__ = ""

--- a/test-environment.yaml
+++ b/test-environment.yaml
@@ -8,7 +8,7 @@ dependencies:
   - numpy>=1.12.0
   - pytest>=3.2.0
   - pytest-cov
-  - pint>=0.7.2
+  - pint==0.11
   - pandas
   - cantera=2.4.0
   - mock


### PR DESCRIPTION
Apparently there is a breaking change in one of the new versions for the
way that I used .units.format_babel. Passing region="EN" works in most
places, but it seems to throw errors when checking pressure units, so
pinning to dev version seemed like the way to go instead.